### PR TITLE
Fix build errors caused by GitHub removal of node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -34,7 +34,7 @@ outputs:
     description: 'A boolean value that indicates an exact match was found.'
 
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/load/index.js'
   post: 'dist/save/index.js'
   post-if: "success() || env.CACHE_ON_FAILURE == 'true'"


### PR DESCRIPTION
Node 16 reached EOL. I just updated the action.yml and everything seems ok with the simple change